### PR TITLE
Add GitHub Actions workflow to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run Deno tests
+        run: deno test --no-check tests/simple_cases_test.ts
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Run Bun tests
+        run: |
+          if [ -f tests/streaming_regression_test.ts ]; then
+            bun test tests/streaming_regression_test.ts
+          else
+            echo "No Bun tests on this branch"
+          fi


### PR DESCRIPTION
Adds a minimal CI workflow that runs the unit tests on every push to `master` and on every pull request: the existing Deno suite (`tests/simple_cases_test.ts`), plus the Bun regression suite from #22 when present on the branch (skipped gracefully otherwise, so this PR and #22 can land in either order).